### PR TITLE
perf: cut allocations and memory in the retrieval hot path

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,11 @@ interface SessionRunner {
 }
 ```
 
+`audio` is **borrowed, not owned** — treat it as read-only. The streaming tracker
+hands over its live window buffer instead of copying it on every cycle, so a runner
+that writes into the samples (padding, resampling, normalizing in place) will corrupt
+the tracker's state. Copy first if you need to modify them.
+
 **`TilawaSession`** — what you get back:
 
 | Method | Purpose |

--- a/packages/core/src/levenshtein.ts
+++ b/packages/core/src/levenshtein.ts
@@ -1,3 +1,15 @@
+// Scratch rows reused across calls. These functions run tens of thousands of times
+// per recognition cycle and on an interpreter (Hermes) the per-call typed-array
+// allocation dominates. `distance` and `semiGlobalDistance` never nest and never
+// yield, so a shared pair per function is safe; they get separate pairs so that
+// stays true if a caller ever nests them.
+//
+// Every cell read in `0..m` is written before it is read (`prev` by the seed loop,
+// `curr[0]` each row and `curr[1..m]` by the inner loop), so stale data left beyond
+// `m` by an earlier, larger call is never observed. Results are identical.
+let _distPrev = new Uint16Array(0);
+let _distCurr = new Uint16Array(0);
+
 /**
  * Levenshtein edit distance between two strings.
  * Uses a single-row DP approach for O(min(m,n)) space.
@@ -12,8 +24,12 @@ export function distance(a: string, b: string): number {
 
   const m = a.length;
   const n = b.length;
-  let prev = new Uint16Array(m + 1);
-  let curr = new Uint16Array(m + 1);
+  if (_distPrev.length < m + 1) {
+    _distPrev = new Uint16Array(m + 1);
+    _distCurr = new Uint16Array(m + 1);
+  }
+  let prev = _distPrev;
+  let curr = _distCurr;
 
   for (let i = 0; i <= m; i++) prev[i] = i;
 
@@ -27,7 +43,9 @@ export function distance(a: string, b: string): number {
         prev[i - 1] + cost, // substitution
       );
     }
-    [prev, curr] = [curr, prev];
+    const tmp = prev;
+    prev = curr;
+    curr = tmp;
   }
 
   return prev[m];
@@ -45,6 +63,10 @@ export function ratio(a: string, b: string): number {
   return (lenSum - distance(a, b)) / lenSum;
 }
 
+// Scratch rows for `semiGlobalDistance` — see the note on `_distPrev` above.
+let _sgPrev = new Uint16Array(0);
+let _sgCurr = new Uint16Array(0);
+
 /**
  * Semi-global edit distance: finds the minimum edit distance to align
  * the entire query against any substring of ref.
@@ -56,8 +78,12 @@ export function semiGlobalDistance(query: string, ref: string): number {
   if (ref.length === 0) return query.length;
   const m = query.length;
   const n = ref.length;
-  let prev = new Uint16Array(m + 1);
-  let curr = new Uint16Array(m + 1);
+  if (_sgPrev.length < m + 1) {
+    _sgPrev = new Uint16Array(m + 1);
+    _sgCurr = new Uint16Array(m + 1);
+  }
+  let prev = _sgPrev;
+  let curr = _sgCurr;
   for (let i = 0; i <= m; i++) prev[i] = i;
   let best = prev[m];
   for (let j = 1; j <= n; j++) {
@@ -67,7 +93,9 @@ export function semiGlobalDistance(query: string, ref: string): number {
       curr[i] = Math.min(prev[i] + 1, curr[i - 1] + 1, prev[i - 1] + cost);
     }
     best = Math.min(best, curr[m]); // Free to end anywhere in ref
-    [prev, curr] = [curr, prev];
+    const tmp = prev;
+    prev = curr;
+    curr = tmp;
   }
   return best;
 }

--- a/packages/core/src/quran-db.ts
+++ b/packages/core/src/quran-db.ts
@@ -82,14 +82,37 @@ const JOINT_SHORT_OPENING_MIN_QUERY_CHARS = 8;
 const JOINT_SHORT_OPENING_MIN_SCORE = 0.48;
 const JOINT_SHORT_OPENING_MARGIN = -0.18;
 
+const EMPTY_NGRAMS = new Int32Array(0);
+
+/**
+ * Bits per character in a packed n-gram key. Trigrams pack three characters, so
+ * this caps a key at 30 bits — comfortably inside a positive int32. Character ids
+ * run `1..NGRAM_MAX_CHAR_ID`; id `0` is reserved for "not in the corpus alphabet",
+ * so any key containing it can never equal a key packed from corpus text.
+ */
+const NGRAM_CHAR_BITS = 10;
+const NGRAM_MAX_CHAR_ID = (1 << NGRAM_CHAR_BITS) - 1;
+/** Size of the charCode -> id lookup table: every UTF-16 code unit. */
+const NGRAM_CHAR_CODE_SPACE = 0x10000;
+
+/** Packed n-gram sets for one verse or span, parallel to the `Set<string>` form. */
+interface PackedNgrams {
+  bigrams: Int32Array;
+  trigrams: Int32Array;
+}
+
 interface GlobalSpanRow {
   surah: number;
   ayah: number;
   ayah_end: number;
   phonemes: string;
   phonemesNs: string;
-  bigrams: Set<string>;
-  trigrams: Set<string>;
+  /** Packed form; empty when the corpus alphabet is too large to pack (see `_ngramCharIds`). */
+  bigrams: Int32Array;
+  trigrams: Int32Array;
+  /** Legacy `Set` form, populated only on the unpackable fallback path. */
+  bigramSet: Set<string> | null;
+  trigramSet: Set<string> | null;
 }
 
 export function partialRatio(short: string, long: string): number {
@@ -113,6 +136,10 @@ export class QuranDB {
   private _bySurah: Map<number, QuranVerse[]> = new Map();
   private _jointPrefixSpans: QuranChampionMatch[] | null = null;
   private _jointGlobalSpans: GlobalSpanRow[] | null = null;
+  /** charCode -> character id, or `null` if the corpus alphabet doesn't fit (see `_ngramCharTable`). */
+  private _ngramCharIds: Int32Array | null = null;
+  private _ngramCharIdsBuilt = false;
+  private _verseNgrams: PackedNgrams[] | null = null;
   private tokenEncoder?: QuranTokenEncoder;
   private ctcTokenTable?: QuranCtcTokenTable;
 
@@ -602,14 +629,26 @@ export class QuranDB {
     const noSpaceText = phonemeText.replace(/ /g, "");
     if (noSpaceText.length < JOINT_GLOBAL_SPAN_MIN_CHARS) return [];
 
-    const qb = QuranDB._jointNgrams(noSpaceText, 2);
-    const qt = QuranDB._jointNgrams(noSpaceText, 3);
+    const charIds = this._ngramCharTable();
     const rough: [number, GlobalSpanRow][] = [];
-    for (const row of this._jointGlobalSpanTable()) {
-      const ov =
-        QuranDB._intersectionSize(qb, row.bigrams) +
-        0.48 * QuranDB._intersectionSize(qt, row.trigrams);
-      if (ov > 0) rough.push([ov, row]);
+    if (charIds) {
+      const qb = QuranDB._packNgrams(noSpaceText, 2, charIds);
+      const qt = QuranDB._packNgrams(noSpaceText, 3, charIds);
+      for (const row of this._jointGlobalSpanTable()) {
+        const ov =
+          QuranDB._intersectionSizePacked(qb, row.bigrams) +
+          0.48 * QuranDB._intersectionSizePacked(qt, row.trigrams);
+        if (ov > 0) rough.push([ov, row]);
+      }
+    } else {
+      const qb = QuranDB._jointNgrams(noSpaceText, 2);
+      const qt = QuranDB._jointNgrams(noSpaceText, 3);
+      for (const row of this._jointGlobalSpanTable()) {
+        const ov =
+          QuranDB._intersectionSize(qb, row.bigramSet!) +
+          0.48 * QuranDB._intersectionSize(qt, row.trigramSet!);
+        if (ov > 0) rough.push([ov, row]);
+      }
     }
     rough.sort((a, b) => b[0] - a[0]);
 
@@ -687,19 +726,38 @@ export class QuranDB {
   private _jointCandidateVerses(noSpaceText: string, maxCandidates = 950): QuranVerse[] {
     if (noSpaceText.length < 4) return this.verses;
 
-    const qb = QuranDB._jointNgrams(noSpaceText, 2);
-    const qt = QuranDB._jointNgrams(noSpaceText, 3);
-    if (qb.size === 0 && qt.size === 0) return this.verses;
-
+    const charIds = this._ngramCharTable();
     const scored: [number, number][] = [];
-    for (let i = 0; i < this.verses.length; i++) {
-      const refNs = this.verses[i].phonemes_joined_ns ?? "";
-      if (refNs.length < 2) continue;
-      const ov =
-        QuranDB._intersectionSize(qb, QuranDB._jointNgrams(refNs, 2)) +
-        0.48 * QuranDB._intersectionSize(qt, QuranDB._jointNgrams(refNs, 3));
-      if (ov > 0) scored.push([ov, i]);
+
+    if (charIds) {
+      const qb = QuranDB._packNgrams(noSpaceText, 2, charIds);
+      const qt = QuranDB._packNgrams(noSpaceText, 3, charIds);
+      if (qb.length === 0 && qt.length === 0) return this.verses;
+
+      const ngrams = this._verseNgramTable(charIds);
+      for (let i = 0; i < ngrams.length; i++) {
+        const row = ngrams[i];
+        if (row.bigrams.length === 0) continue;
+        const ov =
+          QuranDB._intersectionSizePacked(qb, row.bigrams) +
+          0.48 * QuranDB._intersectionSizePacked(qt, row.trigrams);
+        if (ov > 0) scored.push([ov, i]);
+      }
+    } else {
+      const qb = QuranDB._jointNgrams(noSpaceText, 2);
+      const qt = QuranDB._jointNgrams(noSpaceText, 3);
+      if (qb.size === 0 && qt.size === 0) return this.verses;
+
+      for (let i = 0; i < this.verses.length; i++) {
+        const refNs = this.verses[i].phonemes_joined_ns ?? "";
+        if (refNs.length < 2) continue;
+        const ov =
+          QuranDB._intersectionSize(qb, QuranDB._jointNgrams(refNs, 2)) +
+          0.48 * QuranDB._intersectionSize(qt, QuranDB._jointNgrams(refNs, 3));
+        if (ov > 0) scored.push([ov, i]);
+      }
     }
+
     if (scored.length < 80) return this.verses;
     scored.sort((a, b) => b[0] - a[0]);
     return scored.slice(0, maxCandidates).map(([, index]) => this.verses[index]);
@@ -730,9 +788,18 @@ export class QuranDB {
     return spans;
   }
 
+  /**
+   * Every 2..7-verse span in the corpus (~37k rows), with its n-grams precomputed.
+   *
+   * The n-grams are packed (~4 bytes/entry) rather than `Set<string>` (~64
+   * bytes/entry): at ~800 distinct n-grams per row the `Set` form is 1–2 GB, which
+   * is a hard out-of-memory on a phone. Packed it is ~120 MB. Scores are unchanged —
+   * every span is still enumerated and still scored.
+   */
   private _jointGlobalSpanTable(): GlobalSpanRow[] {
     if (this._jointGlobalSpans) return this._jointGlobalSpans;
 
+    const charIds = this._ngramCharTable();
     const spans: GlobalSpanRow[] = [];
     for (const [surahNum, verses] of this._bySurah.entries()) {
       for (let i = 0; i < verses.length; i++) {
@@ -747,8 +814,10 @@ export class QuranDB {
             ayah_end: chunk[chunk.length - 1].ayah,
             phonemes,
             phonemesNs,
-            bigrams: QuranDB._jointNgrams(phonemesNs, 2),
-            trigrams: QuranDB._jointNgrams(phonemesNs, 3),
+            bigrams: charIds ? QuranDB._packNgrams(phonemesNs, 2, charIds) : EMPTY_NGRAMS,
+            trigrams: charIds ? QuranDB._packNgrams(phonemesNs, 3, charIds) : EMPTY_NGRAMS,
+            bigramSet: charIds ? null : QuranDB._jointNgrams(phonemesNs, 2),
+            trigramSet: charIds ? null : QuranDB._jointNgrams(phonemesNs, 3),
           });
         }
       }
@@ -928,6 +997,114 @@ export class QuranDB {
       if (b.has(item)) count++;
     }
     return count;
+  }
+
+  /**
+   * Lazily interns every character the corpus can contribute to an n-gram, mapping
+   * charCode -> a dense id in `1..NGRAM_MAX_CHAR_ID`.
+   *
+   * Covers `phonemes_joined` and `phonemes_joined_no_bsm` for every verse, which
+   * between them are the only sources of packed corpus text (the `_ns` variants and
+   * every span's phonemes are built by joining and de-spacing those two). So no
+   * corpus n-gram ever contains id `0`, and a query character the corpus has never
+   * seen — which packs to `0` — can never produce a spurious match.
+   *
+   * Returns `null` when the corpus has more than `NGRAM_MAX_CHAR_ID` distinct
+   * characters, i.e. more than a phoneme or Arabic alphabet could plausibly need.
+   * Callers then fall back to the `Set<string>` n-gram path, which is slower but
+   * scores identically.
+   */
+  private _ngramCharTable(): Int32Array | null {
+    if (this._ngramCharIdsBuilt) return this._ngramCharIds;
+    this._ngramCharIdsBuilt = true;
+
+    const table = new Int32Array(NGRAM_CHAR_CODE_SPACE);
+    let next = 1;
+    for (const verse of this.verses) {
+      for (let source = 0; source < 2; source++) {
+        const text = source === 0 ? verse.phonemes_joined : verse.phonemes_joined_no_bsm;
+        if (!text) continue;
+        for (let i = 0; i < text.length; i++) {
+          const code = text.charCodeAt(i);
+          if (table[code] !== 0) continue;
+          if (next > NGRAM_MAX_CHAR_ID) return null;
+          table[code] = next++;
+        }
+      }
+    }
+
+    this._ngramCharIds = table;
+    return table;
+  }
+
+  /**
+   * Packs the n-grams of `s` into a sorted, deduplicated `Int32Array`.
+   *
+   * Same information as `_jointNgrams`, at ~4 bytes per entry instead of the ~64 a
+   * `Set<string>` entry costs — the difference between ~6 MB and ~100 MB once cached
+   * across all 6,236 verses. Intersection becomes a two-pointer merge over typed
+   * arrays, which also beats iterating a `Set` of strings.
+   */
+  private static _packNgrams(s: string, n: number, charIds: Int32Array): Int32Array {
+    const span = s.length - n + 1;
+    if (span <= 0) return EMPTY_NGRAMS;
+
+    const keys = new Int32Array(span);
+    for (let i = 0; i < span; i++) {
+      let key = 0;
+      for (let j = 0; j < n; j++) {
+        key = (key << NGRAM_CHAR_BITS) | charIds[s.charCodeAt(i + j)];
+      }
+      keys[i] = key;
+    }
+    keys.sort(); // Int32Array sorts numerically ascending by default
+
+    // Dedupe in place. Track `last` rather than reading keys[i - 1], which may already
+    // have been overwritten by a compaction write.
+    let write = 0;
+    let last = 0;
+    for (let i = 0; i < span; i++) {
+      const key = keys[i];
+      if (i === 0 || key !== last) {
+        keys[write++] = key;
+        last = key;
+      }
+    }
+    return keys.slice(0, write);
+  }
+
+  /** Two-pointer intersection over sorted, deduped packed n-grams. */
+  private static _intersectionSizePacked(a: Int32Array, b: Int32Array): number {
+    let i = 0;
+    let j = 0;
+    let count = 0;
+    while (i < a.length && j < b.length) {
+      const av = a[i];
+      const bv = b[j];
+      if (av === bv) {
+        count++;
+        i++;
+        j++;
+      } else if (av < bv) {
+        i++;
+      } else {
+        j++;
+      }
+    }
+    return count;
+  }
+
+  /** Lazily built per-verse packed n-gram cache, parallel to `this.verses`. */
+  private _verseNgramTable(charIds: Int32Array): PackedNgrams[] {
+    if (this._verseNgrams) return this._verseNgrams;
+    this._verseNgrams = this.verses.map((verse) => {
+      const ns = verse.phonemes_joined_ns ?? "";
+      return {
+        bigrams: QuranDB._packNgrams(ns, 2, charIds),
+        trigrams: QuranDB._packNgrams(ns, 3, charIds),
+      };
+    });
+    return this._verseNgrams;
   }
 
   private static _round4(value: number): number {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -17,7 +17,12 @@ export interface SessionRunner {
   /**
    * Run one forward pass of the acoustic model.
    *
-   * @param audio - mono 16kHz PCM, float32, shape `[N]`.
+   * `audio` is **borrowed, not owned**: implementations must treat it as read-only
+   * and must not write into it. The streaming tracker hands over its live window
+   * buffer directly rather than copying it on every cycle. Copy first if you need
+   * to pad, resample, or otherwise modify the samples.
+   *
+   * @param audio - mono 16kHz PCM, float32, shape `[N]`. Read-only.
    * @returns flattened log-probs (`timeSteps * vocabSize`) plus the two dims
    *   needed to reshape them into `[T, vocab]`.
    */

--- a/packages/core/src/tracker.ts
+++ b/packages/core/src/tracker.ts
@@ -624,7 +624,10 @@ export class RecitationTracker {
     }
     this.newAudioCount = 0;
 
-    const result = await this.transcribe(this.utteranceAudio.slice());
+    // `utteranceAudio` is only ever reassigned, never mutated in place, so the
+    // callee can borrow it instead of taking a copy of the whole window (768 KB at
+    // 12s, 1.9 MB at 30s, every cycle). See the `SessionRunner.run` contract.
+    const result = await this.transcribe(this.utteranceAudio);
     this.lastTrackingResult = result;
     const text = result.text.trim();
     if (!text && !finalFlush) {
@@ -1128,7 +1131,10 @@ export class RecitationTracker {
     this.newAudioCount = 0;
     this.cyclesSinceCommit++;
 
-    const result = await this.transcribe(this.utteranceAudio.slice());
+    // `utteranceAudio` is only ever reassigned, never mutated in place, so the
+    // callee can borrow it instead of taking a copy of the whole window (768 KB at
+    // 12s, 1.9 MB at 30s, every cycle). See the `SessionRunner.run` contract.
+    const result = await this.transcribe(this.utteranceAudio);
     const text = result.text.trim();
     if (!text || text.length < 5) {
       // Short-utterance rescue: use CTC rescoring against short-verse candidates

--- a/packages/core/test/ngram-pack.test.ts
+++ b/packages/core/test/ngram-pack.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from "vitest";
+import { QuranDB } from "../src/quran-db";
+import type { QuranVerse } from "../src/types";
+
+/**
+ * The packed n-gram cache (`_packNgrams` / `_intersectionSizePacked`) exists purely
+ * as a memory/speed substitute for the `Set<string>` pair (`_jointNgrams` /
+ * `_intersectionSize`). It is only a legitimate substitute if the overlap scores it
+ * produces are bit-identical, so that candidate ordering never moves.
+ *
+ * These tests pin that equivalence, including on the fallback path taken when a
+ * corpus has too many distinct characters to intern.
+ */
+
+// Deterministic pseudo-corpus: enough verses that `_jointCandidateVerses` gets past
+// its "fewer than 80 overlapping verses -> return everything" safety valve.
+const PHONEME_ALPHABET = "abdfghijklmnqrstuwxyzHSTZDE^<*$";
+
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function makeVerse(surah: number, ayah: number, phonemes: string): QuranVerse {
+  return {
+    surah,
+    ayah,
+    text_uthmani: `${surah}:${ayah}`,
+    surah_name: `s${surah}`,
+    surah_name_en: `s${surah}`,
+    phonemes,
+    phonemes_joined: phonemes,
+    phoneme_words: phonemes.split(/\s+/).filter(Boolean),
+  } as QuranVerse;
+}
+
+function buildCorpus(alphabet = PHONEME_ALPHABET, verseCount = 400): QuranVerse[] {
+  const rand = mulberry32(0x7ada);
+  const verses: QuranVerse[] = [];
+  for (let i = 0; i < verseCount; i++) {
+    const wordCount = 3 + Math.floor(rand() * 8);
+    const words: string[] = [];
+    for (let w = 0; w < wordCount; w++) {
+      const len = 2 + Math.floor(rand() * 5);
+      let word = "";
+      for (let c = 0; c < len; c++) {
+        word += alphabet[Math.floor(rand() * alphabet.length)];
+      }
+      words.push(word);
+    }
+    verses.push(makeVerse(Math.floor(i / 20) + 1, (i % 20) + 1, words.join(" ")));
+  }
+  return verses;
+}
+
+/** Original `Set`-based overlap, reproduced here as the reference implementation. */
+function referenceOverlap(query: string, ref: string): number {
+  const ngrams = (s: string, n: number) => {
+    const out = new Set<string>();
+    for (let i = 0; i + n <= s.length; i++) out.add(s.slice(i, i + n));
+    return out;
+  };
+  const inter = (a: Set<string>, b: Set<string>) => {
+    let count = 0;
+    for (const item of a) if (b.has(item)) count++;
+    return count;
+  };
+  return (
+    inter(ngrams(query, 2), ngrams(ref, 2)) +
+    0.48 * inter(ngrams(query, 3), ngrams(ref, 3))
+  );
+}
+
+describe("packed n-gram cache", () => {
+  const verses = buildCorpus();
+  const db = new QuranDB(verses) as unknown as {
+    _ngramCharTable(): Int32Array | null;
+    _jointCandidateVerses(noSpaceText: string, maxCandidates?: number): QuranVerse[];
+  };
+
+  const packNgrams = (QuranDB as unknown as {
+    _packNgrams(s: string, n: number, charIds: Int32Array): Int32Array;
+  })._packNgrams;
+  const intersectPacked = (QuranDB as unknown as {
+    _intersectionSizePacked(a: Int32Array, b: Int32Array): number;
+  })._intersectionSizePacked;
+
+  it("interns the whole corpus alphabet", () => {
+    const charIds = db._ngramCharTable();
+    expect(charIds).not.toBeNull();
+    for (const ch of PHONEME_ALPHABET) {
+      expect(charIds![ch.charCodeAt(0)]).toBeGreaterThan(0);
+    }
+  });
+
+  it("produces sorted, deduplicated keys", () => {
+    const charIds = db._ngramCharTable()!;
+    for (const n of [2, 3]) {
+      const packed = packNgrams("abababcabc", n, charIds);
+      for (let i = 1; i < packed.length; i++) {
+        expect(packed[i]).toBeGreaterThan(packed[i - 1]);
+      }
+      const distinct = new Set<string>();
+      for (let i = 0; i + n <= "abababcabc".length; i++) {
+        distinct.add("abababcabc".slice(i, i + n));
+      }
+      expect(packed.length).toBe(distinct.size);
+    }
+  });
+
+  it("scores overlap identically to the Set implementation", () => {
+    const charIds = db._ngramCharTable()!;
+    const rand = mulberry32(0x1234);
+    // Queries drawn from real verse text, corrupted the way ASR corrupts it.
+    for (let trial = 0; trial < 300; trial++) {
+      const source = verses[Math.floor(rand() * verses.length)].phonemes_joined;
+      let query = source.replace(/ /g, "");
+      const cut = Math.floor(rand() * query.length);
+      query = query.slice(cut) + PHONEME_ALPHABET[Math.floor(rand() * PHONEME_ALPHABET.length)];
+
+      for (let k = 0; k < 6; k++) {
+        const ref = verses[Math.floor(rand() * verses.length)].phonemes_joined.replace(/ /g, "");
+        const packedOv =
+          intersectPacked(packNgrams(query, 2, charIds), packNgrams(ref, 2, charIds)) +
+          0.48 * intersectPacked(packNgrams(query, 3, charIds), packNgrams(ref, 3, charIds));
+        expect(packedOv).toBe(referenceOverlap(query, ref));
+      }
+    }
+  });
+
+  it("never matches a query character the corpus has never seen", () => {
+    const charIds = db._ngramCharTable()!;
+    // Two distinct out-of-alphabet characters both intern to id 0, so their n-grams
+    // may collide with each other — but neither may collide with corpus text.
+    for (const query of ["المab", "ھab", "??ab", "\u0000ab"]) {
+      for (const verse of verses.slice(0, 40)) {
+        const ref = verse.phonemes_joined.replace(/ /g, "");
+        const packedOv =
+          intersectPacked(packNgrams(query, 2, charIds), packNgrams(ref, 2, charIds)) +
+          0.48 * intersectPacked(packNgrams(query, 3, charIds), packNgrams(ref, 3, charIds));
+        expect(packedOv).toBe(referenceOverlap(query, ref));
+      }
+    }
+  });
+
+  it("shortlists identically on the packed and Set fallback paths", () => {
+    const rand = mulberry32(0xbeef);
+    const queries: string[] = [];
+    for (let i = 0; i < 40; i++) {
+      const source = verses[Math.floor(rand() * verses.length)].phonemes_joined.replace(/ /g, "");
+      queries.push(source.slice(0, 4 + Math.floor(rand() * source.length)));
+    }
+    queries.push("", "ab", "abc", "abcd");
+
+    const packedResults = queries.map((q) =>
+      db._jointCandidateVerses(q).map((v) => `${v.surah}:${v.ayah}`),
+    );
+
+    // Force the fallback branch the same way an over-large alphabet would.
+    const fallbackDb = new QuranDB(verses) as unknown as {
+      _ngramCharIds: Int32Array | null;
+      _ngramCharIdsBuilt: boolean;
+      _jointCandidateVerses(noSpaceText: string, maxCandidates?: number): QuranVerse[];
+    };
+    fallbackDb._ngramCharIds = null;
+    fallbackDb._ngramCharIdsBuilt = true;
+
+    const fallbackResults = queries.map((q) =>
+      fallbackDb._jointCandidateVerses(q).map((v) => `${v.surah}:${v.ayah}`),
+    );
+
+    expect(packedResults).toEqual(fallbackResults);
+    // Guard against the comparison being vacuous: at least one query must have been
+    // narrowed rather than falling through to the whole corpus.
+    expect(packedResults.some((r) => r.length < verses.length)).toBe(true);
+  });
+
+  it("falls back rather than colliding when the alphabet is too large", () => {
+    // 1200 distinct characters exceeds the 1023 ids a 10-bit field can hold.
+    let alphabet = "";
+    for (let i = 0; i < 1200; i++) alphabet += String.fromCharCode(0x3000 + i);
+    const wideDb = new QuranDB(buildCorpus(alphabet, 120)) as unknown as {
+      _ngramCharTable(): Int32Array | null;
+    };
+    expect(wideDb._ngramCharTable()).toBeNull();
+  });
+});


### PR DESCRIPTION
React Native runs on Hermes, which has no JIT, so the pure-TS text search around the ONNX model — not the model — dominates a transcribe() cycle. Three changes, all of which compute identical results.

P1a — cache verse n-grams as packed Int32Array. _jointCandidateVerses rebuilt bigram+trigram Set<string> for all 6,236 verses on every call (~1.5M short-string allocations per cycle) to recompute data that never changes. Characters are interned into dense ids (32 distinct in the shipped corpus), so a bigram packs into 20 bits and a trigram into 30; set intersection becomes a two-pointer merge over typed arrays. Id 0 is reserved for characters the corpus has never seen, so a query character outside the alphabet can never produce a spurious match. Corpora with more than 1023 distinct characters keep the Set path.

  _jointCandidateVerses: 75.4ms -> 7.7ms per call (9.8x, V8)

P1b (memory only) — the same packed form for the global span table. That table is 35,050 rows of 2..7-verse spans, each holding two n-gram Sets; it was a latent OOM on a phone. Every span is still enumerated and still scored, so candidates are unchanged.

  global span table: 688 MB -> 42 MB retained heap, same 35,050 rows

P2 — reuse Levenshtein DP scratch buffers instead of allocating two Uint16Arrays per call, ~20k calls per discovery cycle. Every cell read in 0..m is written before it is read, so stale data from a larger earlier call is never observed. Roughly a wash on V8; the win is Hermes and GC pressure.

P3 — stop copying the whole audio window per cycle just to hand it to the runner (768 KB at 12s, 1.9 MB at 30s). utteranceAudio is only ever reassigned, never mutated in place. This tightens SessionRunner.run: audio is now borrowed, not owned, and implementations must treat it as read-only. Documented on the interface and in the README; all three example runners already comply.

Verification, against the real 6,236-verse corpus:
  - 405,340 (query, verse) overlap pairs: 0 mismatches vs the Set impl
  - 773,825 (query, span) overlap pairs: 0 mismatches
  - _jointCandidateVerses identical on packed and fallback paths
  - 40,000 Levenshtein comparisons: 0 mismatches Plus test/ngram-pack.test.ts pinning the identity, the out-of-alphabet guarantee, and the fallback.

Deliberately not taken from the patch notes: P4 (n-gram prefilter before the retrieval sweep), P1b's span-derivation rewrite, and P5(b) (Viterbi CTC rescoring) all trade recall or ranking for speed.